### PR TITLE
Fix client API url parameters

### DIFF
--- a/clockify_api_client/models/client.py
+++ b/clockify_api_client/models/client.py
@@ -18,7 +18,7 @@ class Client(AbstractClockify):
         try:
             if params:
                 url_params = urlencode(params, doseq=True)
-                url = self.base_url + '/workspaces/' + workspace_id + '/clients&' + url_params
+                url = self.base_url + '/workspaces/' + workspace_id + '/clients?' + url_params
             else:
                 url = self.base_url + '/workspaces/' + workspace_id + '/clients/'
             return self.get(url)


### PR DESCRIPTION
## Test code
```python
API_KEY = 'xxx'
API_URL = 'api.clockify.me/v1'
WORKSPACE_ID = "xxx"

api_client = ClockifyAPIClient().build(API_KEY, API_URL)
client = api_client.clients.get_clients(WORKSPACE_ID, {"name": "Client1"})
```

## Before fix
```
Exception: {'timestamp': '2022-09-18T10:48:01.439+00:00', 'status': 404, 'error': 'Not Found', 'path': '/v1/workspaces/xxx/clients&name=Client1'}
```

## After fix
```
[{'id': 'xxx', 'name': 'Client1', 'workspaceId': 'xxx', 'archived': False, 'address': None, 'note': None}]
```

Please also cut a release and push to PyPI. Thanks!