### PR TITLE
Custom fields and create project with dictionary

### DIFF
--- a/clockify_api_client/abstract_clockify.py
+++ b/clockify_api_client/abstract_clockify.py
@@ -6,7 +6,10 @@ import requests
 class AbstractClockify(ABC):
     def __init__(self, api_key, api_url):
 
-        self.base_url = f'https://global.{api_url}'.strip('/')
+        # Current API docs don't contain the "global" and the response time
+        # seems faster without it (although it works fine)
+        # self.base_url = f'https://global.{api_url}'.strip('/')
+        self.base_url = f'https://{api_url}'.strip('/')
         self.api_key = api_key
         self.header = {'X-Api-Key': self.api_key}
 
@@ -33,3 +36,10 @@ class AbstractClockify(ABC):
         if response.status_code in [200, 201, 202, 204]:
             return response.json()
         raise Exception(response.json())
+
+    def patch(self, url, payload):
+        response = requests.patch(url, headers=self.header, json=payload)
+        if response.status_code in [200, 201, 202, 204]:
+            return response.json()
+        raise Exception(response.json())
+

--- a/clockify_api_client/client.py
+++ b/clockify_api_client/client.py
@@ -6,6 +6,7 @@ from clockify_api_client.factories.time_entry_factory import TimeEntryFactory
 from clockify_api_client.factories.user_factory import UserFactory
 from clockify_api_client.factories.workspace_factory import WorkspaceFactory
 from clockify_api_client.factories.client_factory import ClientFactory
+from clockify_api_client.factories.custom_field_factory import CustomFieldFactory
 from clockify_api_client.utils import Singleton
 
 
@@ -19,6 +20,7 @@ class ClockifyAPIClient(metaclass=Singleton):
         self.users = None
         self.reports = None
         self.clients = None
+        self.custom_fields = None
 
     def build(self, api_key, api_url):
         """Builds services from available factories.
@@ -34,4 +36,5 @@ class ClockifyAPIClient(metaclass=Singleton):
         self.users = UserFactory(api_key=api_key, api_url=api_url)
         self.reports = ReportFactory(api_key=api_key, api_url=api_url)
         self.clients = ClientFactory(api_key=api_key, api_url=api_url)
+        self.custom_fields = CustomFieldFactory(api_key=api_key, api_url=api_url)
         return self

--- a/clockify_api_client/factories/custom_field_factory.py
+++ b/clockify_api_client/factories/custom_field_factory.py
@@ -1,0 +1,7 @@
+from clockify_api_client.factories.abstract_factory import AbstractFactory
+from clockify_api_client.models.custom_field import CustomField
+
+
+class CustomFieldFactory(AbstractFactory):
+    class Meta:
+        model = CustomField

--- a/clockify_api_client/models/custom_field.py
+++ b/clockify_api_client/models/custom_field.py
@@ -1,0 +1,99 @@
+import logging
+from urllib.parse import urlencode
+
+from clockify_api_client.abstract_clockify import AbstractClockify
+
+
+class CustomField(AbstractClockify):
+
+    def __init__(self, api_key, api_url):
+        super(CustomField, self).__init__(api_key=api_key, api_url=api_url)
+
+
+    #def add_client(self, workspace_id, name=None, note=None):
+        #"""Adds new client.
+        #:param workspace_id Id of workspace to look for clients.
+        #:param name         Name of the new client.
+        #:param note         Description of client
+        #:return             Dictionary representation of new client.
+        #"""
+        #try:
+            #assert name
+            #data = {
+                #'name': name,
+                #'note' : note
+            #}
+            #url = self.base_url + '/workspaces/' + workspace_id + '/clients/'
+            #return self.post(url, payload=data)
+        #except Exception as e:
+            #logging.error("API error: {0}".format(e))
+            #raise e
+
+    #def get_clients(self, workspace_id, params=None):
+        #"""Returns all clients.
+        #:param workspace_id Id of workspace to look for clients.
+        #:param params       URL params of request.
+        #:return             List of clients(dict objects).
+        #"""
+        #try:
+            #if params:
+                #url_params = urlencode(params, doseq=True)
+                #url = self.base_url + '/workspaces/' + workspace_id + '/clients?' + url_params
+            #else:
+                #url = self.base_url + '/workspaces/' + workspace_id + '/clients/'
+            #return self.get(url)
+        #except Exception as e:
+            #logging.error("API error: {0}".format(e))
+            #raise e
+
+    def get_custom_fields(self, workspace_id, params=None):
+        """Returns all custom fields in the workspace.
+        :param workspace_id Id of workspace to look for custom fields.
+        :param params       URL params of request.
+        :return             List of custom fields(dict objects).
+        """
+        try:
+            if params:
+                url_params = urlencode(params, doseq=True)
+                url = self.base_url + '/workspaces/' + workspace_id + '/custom-fields?' + url_params
+            else:
+                url = self.base_url + '/workspaces/' + workspace_id + '/custom-fields/'
+            return self.get(url)
+        except Exception as e:
+            logging.error("API error: {0}".format(e))
+            raise e
+
+    def get_project_custom_fields(self, workspace_id, project_id, params={'status': 'VISIBLE',}):
+        url_params = urlencode(params, doseq=True)
+        url = self.base_url + '/workspaces/' + workspace_id + '/projects/' + project_id + '/custom-fields?' + url_params
+
+        print(url)
+
+        try:
+            return self.get(url)
+        except Exception as e:
+            logging.error('API error: {0}'.format(e))
+            raise e
+
+    def update_project_custom_field(self, workspace_id, project_id, custom_field_id, value, isVisible=True):
+        """Returns all custom fields in the workspace.
+        :param workspace_id Id of workspace.
+        :param project_id Id of project.
+        :param value Value to set
+        :param isVisible Boolean to set visiblity
+        """
+        try:
+            if isVisible:
+                status = "VISIBLE"
+            else:
+                status = "INVISIBLE"
+
+            custom_field_details = {'defaultValue': value,
+                                    'status': status}
+
+            url = self.base_url + '/workspace/' + workspace_id + '/projects/' + project_id + '/custom-fields/' + custom_field_id
+
+            return self.patch(url, custom_field_details)
+        except Exception as e:
+            logging.error("API error: {0}".format(e))
+            raise e

--- a/clockify_api_client/models/custom_field.py
+++ b/clockify_api_client/models/custom_field.py
@@ -9,48 +9,11 @@ class CustomField(AbstractClockify):
     def __init__(self, api_key, api_url):
         super(CustomField, self).__init__(api_key=api_key, api_url=api_url)
 
-
-    #def add_client(self, workspace_id, name=None, note=None):
-        #"""Adds new client.
-        #:param workspace_id Id of workspace to look for clients.
-        #:param name         Name of the new client.
-        #:param note         Description of client
-        #:return             Dictionary representation of new client.
-        #"""
-        #try:
-            #assert name
-            #data = {
-                #'name': name,
-                #'note' : note
-            #}
-            #url = self.base_url + '/workspaces/' + workspace_id + '/clients/'
-            #return self.post(url, payload=data)
-        #except Exception as e:
-            #logging.error("API error: {0}".format(e))
-            #raise e
-
-    #def get_clients(self, workspace_id, params=None):
-        #"""Returns all clients.
-        #:param workspace_id Id of workspace to look for clients.
-        #:param params       URL params of request.
-        #:return             List of clients(dict objects).
-        #"""
-        #try:
-            #if params:
-                #url_params = urlencode(params, doseq=True)
-                #url = self.base_url + '/workspaces/' + workspace_id + '/clients?' + url_params
-            #else:
-                #url = self.base_url + '/workspaces/' + workspace_id + '/clients/'
-            #return self.get(url)
-        #except Exception as e:
-            #logging.error("API error: {0}".format(e))
-            #raise e
-
     def get_custom_fields(self, workspace_id, params=None):
         """Returns all custom fields in the workspace.
         :param workspace_id Id of workspace to look for custom fields.
         :param params       URL params of request.
-        :return             List of custom fields(dict objects).
+        :return             List of custom fields (dict objects).
         """
         try:
             if params:
@@ -64,23 +27,28 @@ class CustomField(AbstractClockify):
             raise e
 
     def get_project_custom_fields(self, workspace_id, project_id, params={'status': 'VISIBLE',}):
-        url_params = urlencode(params, doseq=True)
-        url = self.base_url + '/workspaces/' + workspace_id + '/projects/' + project_id + '/custom-fields?' + url_params
-
-        print(url)
-
+        """Return the custom fields for a specific project.
+        :param workspace_id Id of workspace containing the project.
+        :param project_id   Id of project to look for custom fields.
+        :param params       URL params of request.
+        :return             List of custom fields (dict objects).
+        """
         try:
+            url_params = urlencode(params, doseq=True)
+            url = self.base_url + '/workspaces/' + workspace_id + '/projects/' + project_id + '/custom-fields?' + url_params
             return self.get(url)
         except Exception as e:
             logging.error('API error: {0}'.format(e))
             raise e
 
     def update_project_custom_field(self, workspace_id, project_id, custom_field_id, value, isVisible=True):
-        """Returns all custom fields in the workspace.
-        :param workspace_id Id of workspace.
-        :param project_id Id of project.
-        :param value Value to set
-        :param isVisible Boolean to set visiblity
+        """Update specified custom field in the project.
+        :param workspace_id    Id of workspace.
+        :param project_id      Id of project.
+        :param custom_field_id Id of custom field.
+        :param value           Value to set the custom field to.
+        :param isVisible       Boolean to set visibilty of the custom field.
+        :return                Dictionary of updated custom field.
         """
         try:
             if isVisible:

--- a/clockify_api_client/models/project.py
+++ b/clockify_api_client/models/project.py
@@ -46,3 +46,18 @@ class Project(AbstractClockify):
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
+
+    def add_project_from_dict(self, workspace_id, project_dict):
+        """Add new project into workspace, built from a dictionary.
+        :param workspace_id ID of workspace.
+        :param project_dict Dictionary containing all the project details.
+        :return             Dictionary representation of new project.
+        """
+        
+        try:
+            url = self.base_url + '/workspaces/' + workspace_id + '/projects/'
+            return self.post(url, project_dict)
+        except Exception as e:
+            logging.error('API error:{0}'.format(e))
+            raise e
+


### PR DESCRIPTION
I extended the api client a little by adding some handling of custom fields and creating a new method to create projects with a dictionary.

- Add Custom Field handling. Get workspace-global custom fields, project-specific custom fields, and update specific custom fields.
- Add creating project using a dictionary. Allows creating more complete/complex projects.